### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/actions-updater-test.yml
+++ b/.github/workflows/actions-updater-test.yml
@@ -24,7 +24,7 @@ jobs:
 
       # Run GitHub Actions Version Updater from your fork
       - name: Run GitHub Actions Version Updater
-        uses: charl3y15/github-actions-version-updater@main #add-Docker-update
+        uses: charl3y15/github-actions-version-updater@1.2 #add-Docker-update
         with:
           token: ${{ secrets.GH_TOKEN }}
           skip_pull_request: "false"


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[charl3y15/github-actions-version-updater](https://github.com/charl3y15/github-actions-version-updater)** published a new release **[1.2](https://github.com/charl3y15/github-actions-version-updater/releases/tag/1.2)** on 2025-04-20T15:55:43Z
