### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4.2.2
 
       - name: Download cache archive
-        uses: dawidd6/action-download-artifact@v10
+        uses: dawidd6/action-download-artifact@v11
         with:
           name: ${{ env.cache_key }}
           path: cache-download


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[dawidd6/action-download-artifact](https://github.com/dawidd6/action-download-artifact)** published a new release **[v11](https://github.com/dawidd6/action-download-artifact/releases/tag/v11)** on 2025-06-14T21:24:37Z
